### PR TITLE
Remove root conjob since it's redundant.

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -10,12 +10,3 @@
     owner: root
     group: root
     mode: 0644
-
-- name: Tmpreaper | Set the tmpreaper cron
-  cron:
-    name: tmpreaper
-    hour: "{{tmpreaper_cron_hour}}"
-    minute: "{{tmpreaper_cron_minute}}"
-    job: /usr/sbin/tmpreaper
-  notify:
-    - restart cron


### PR DESCRIPTION
The tmpreaper package already installs a job in the /etc/cron.daily folder already that calls the `/usr/sbin/tmpreaper` with the configuration values in `/etc/tmpreaper.conf`
